### PR TITLE
update-v-card-title設定

### DIFF
--- a/pages/lucky.vue
+++ b/pages/lucky.vue
@@ -2,11 +2,11 @@
   <div>
     <h1>爆発</h1>
     <img :src="image_src" />
-    <v-card>
-      <h1>Let's Bakudan talk</h1>
-      {{ test }}
-      {{ test2 }}
-      <v-btn to="/" nuxt>もう一度</v-btn>
+    <v-card v-if="test">
+      <v-card-title>Let's Bakudan talk</v-card-title>
+        <v-card-text>{{ test }}</v-card-text>
+        <v-card-text>{{ test2 }}</v-card-text>
+        <v-btn to="/" nuxt>もう一度</v-btn>
     </v-card>
   </div>
 </template>


### PR DESCRIPTION
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
`v-card`内のタグ名の変更しました。
今後、text位置をcenterにします。

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
<img width="1184" alt="スクリーンショット 2021-04-07 23 55 45" src="https://user-images.githubusercontent.com/71075728/113892381-e2f41100-9800-11eb-9422-1436c07ba3eb.png">
