### PR TITLE
[本番環境]説明文画面

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -6,19 +6,19 @@
               <v-card-title primary-title class="justify-center">遊びかた
               </v-card-title>
               <v-card-text>
-                <p class="parent">
+                <p>
                     <v-icon color="#fffffe">mdi-numeric-1-circle</v-icon>
                     １〜３回 好きな回数爆弾をクリック！！
                 </p>
-                <p class="parent">
+                <p>
                     <v-icon color="#fffffe">mdi-numeric-2-circle</v-icon>
                     ランダムで爆弾が爆発！！
                 </p>
-                <p class="parent">
+                <p>
                     <v-icon color="#fffffe">mdi-numeric-3-circle</v-icon>
                     爆発させてしまった方は、表示されたお題について暴露話し！
                 </p>
-                <p class="parent">
+                <p>
                     <v-icon color="#fffffe">mdi-numeric-4-circle</v-icon>
                     リプレイボタンを押してもう一周♪
                 </p>


### PR DESCRIPTION
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
爆発させたのち、howtoページに遷移すると、lucky.vueのclass="parent"が適用され、about.vueの説明分に余計なcssがついてしまうため、about.vueのクラス指定なしにして、余計なcssがかからないようにしました。

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
<img width="756" alt="スクリーンショット 2021-06-30 16 29 12" src="https://user-images.githubusercontent.com/71075728/123919836-4f297f80-d9c0-11eb-8711-c74426cb4070.png">
